### PR TITLE
Support for iOS 9 above when building using Xcode 7+ (1. crash causin…

### DIFF
--- a/MyWeibo/Classes/Other/View/TGScrollTopWindow.m
+++ b/MyWeibo/Classes/Other/View/TGScrollTopWindow.m
@@ -18,6 +18,8 @@ static UIWindow *window_;
     window_.frame = CGRectMake(0, 0, TGScreenW, 20);
     window_.windowLevel = UIWindowLevelAlert;
     [window_ addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(windowClick)]];
+    UIViewController* vc = [[UIViewController alloc]initWithNibName:nil bundle:nil];
+    window_.rootViewController = vc;
 }
 
 + (void)show {

--- a/MyWeibo/Info.plist
+++ b/MyWeibo/Info.plist
@@ -20,6 +20,10 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key><true/>
+    </dict>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
…g by UIWindow missing rootviewcontroller 2. ATS temp allow insecure loads)